### PR TITLE
FB-40681 Prevent updating existing changes

### DIFF
--- a/drivers/README.txt
+++ b/drivers/README.txt
@@ -1,1 +1,0 @@
-Any jar file placed in this directory (eg, a database driver) will be included in classpath for the unit tests.

--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>3.8.1</version>
+            <version>4.12</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -36,12 +36,6 @@
                 </configuration>
             </plugin>
         </plugins>
-
-        <testResources>
-            <testResource>
-                <directory>drivers</directory>
-            </testResource>
-        </testResources>
     </build>
 
     <inceptionYear>2003</inceptionYear>

--- a/pom.xml
+++ b/pom.xml
@@ -82,6 +82,13 @@
             <version>1.0.1</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <version>1.4.197</version>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
     <reports>

--- a/src/main/java/org/sourceforge/uptodater/Updater.java
+++ b/src/main/java/org/sourceforge/uptodater/Updater.java
@@ -200,13 +200,13 @@ public class Updater {
     boolean alreadyApplied(String description) {
         if (existingDescriptions.contains(description)) {
             return true;
-        } else {
-            // Some databases - eg sqlserver - have odd case sensitivities;
-            // this check should not be necessary
-            for (String cmd : existingDescriptions) {
-                if (cmd.equalsIgnoreCase(description)) {
-                    return true;
-                }
+        }
+
+        // Some databases - eg sqlserver - have odd case sensitivities;
+        // this check should not be necessary
+        for (String cmd : existingDescriptions) {
+            if (cmd.equalsIgnoreCase(description)) {
+                return true;
             }
         }
         return false;

--- a/src/test/java/org/sourceforge/uptodater/UpdaterTest.java
+++ b/src/test/java/org/sourceforge/uptodater/UpdaterTest.java
@@ -74,7 +74,6 @@ public class UpdaterTest {
 
     @Test
     public void doNotUpdateSameDescription() throws SQLException {
-        assertTrue(true);
         Updater updater = new Updater(TABLE_NAME);
         updater.initialize(getConnection(), "");
         String createTable = "create table test_table (\n"

--- a/src/test/java/org/sourceforge/uptodater/UpdaterTest.java
+++ b/src/test/java/org/sourceforge/uptodater/UpdaterTest.java
@@ -1,0 +1,87 @@
+package org.sourceforge.uptodater;
+
+import static org.junit.Assert.*;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Properties;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class UpdaterTest {
+
+    private static String TABLE_NAME = "uptodater";
+    private static Connection connection;
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        Properties properties = new Properties();
+        properties.load(UpdaterTest.class.getResourceAsStream("/UpToDater.properties"));
+
+        Class.forName(properties.getProperty("jdbc.driverClassName"));
+        connection = DriverManager.getConnection(properties.getProperty("jdbc.url"));
+        createTestTable();
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+        try {
+            dropTable();
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+    }
+
+    private static Connection getConnection() {
+        return connection;
+    }
+
+    private static void createTestTable() throws SQLException {
+        String sql = "create table " + TABLE_NAME + " (\n" +
+                "    sqltext_hash varchar(100) primary key not null,\n" +
+                "    insert_date datetime not null default getdate(),\n" +
+                "    description varchar(250) not null,\n" +
+                "    sqltext text,\n" +
+                "    change_id int auto_increment,\n" +
+                "    applied_date datetime\n" +
+                ");";
+
+        Connection conn;
+        Statement stmt = null;
+        try {
+            conn = getConnection();
+            stmt = conn.createStatement();
+            stmt.execute(sql);
+        } finally {
+            DBUtil.close(stmt);
+        }
+    }
+
+    private static void dropTable() throws Exception{
+        Connection conn = null;
+        Statement stmt = null;
+        try {
+            conn = getConnection();
+            stmt = conn.createStatement();
+            stmt.execute("drop table " + TABLE_NAME + ";");
+        } finally {
+            DBUtil.closeAll(conn, stmt);
+        }
+    }
+
+    @Test
+    public void doNotUpdateSameDescription() throws SQLException {
+        assertTrue(true);
+        Updater updater = new Updater(TABLE_NAME);
+        updater.initialize(getConnection(), "");
+        String createTable = "create table test_table (\n"
+                + "  id int auto_increment not null\n"
+                + ")";
+        updater.update("file1.sql", createTable);
+        updater.update("file1.sql", createTable + " -- and a slight change");
+        assertEquals(1, updater.getUnappliedChanges().size());
+    }
+}

--- a/src/test/resources/UpToDater.properties
+++ b/src/test/resources/UpToDater.properties
@@ -1,4 +1,2 @@
-default.url=jdbc:jtds:sqlserver://localhost:1433/uptodater
-default.driver-class=net.sourceforge.jtds.jdbc.Driver
-default.user=jdbc
-default.password=password
+jdbc.driverClassName=org.h2.Driver
+jdbc.url=jdbc:h2:mem:myDb;DB_CLOSE_DELAY=-1


### PR DESCRIPTION
Do not allow updates to an existing change of the same description when
it already exists. Previously, uniqueness was defined based upon the
text of the change. As a result, updating a file would cause the change
to rerun even though it may not be safe to do so.
    
With these changes, updating a change that has already been applied will
have no effect.
