### PR TITLE
FB-40681 Do not update if description changes

### DIFF
--- a/src/main/java/org/sourceforge/uptodater/UpToDateRunner.java
+++ b/src/main/java/org/sourceforge/uptodater/UpToDateRunner.java
@@ -222,7 +222,7 @@ public abstract class UpToDateRunner  {
             boolean noUpdate = dryRun || isInactive();
             for(String source : scriptsMap.keySet()) {
                 String contents =  scriptsMap.get(source);
-                if (noUpdate && !updater.alreadyApplied(source)) {
+                if (noUpdate && !updater.alreadyApplied(source, contents)) {
                     logApplied(appliedScriptNames, source, contents);
                 } else if (updater.update(source, contents)) {
                     logApplied(appliedScriptNames, source, contents);

--- a/src/test/java/org/sourceforge/uptodater/UpdaterTest.java
+++ b/src/test/java/org/sourceforge/uptodater/UpdaterTest.java
@@ -83,4 +83,16 @@ public class UpdaterTest {
         updater.update("file1.sql", createTable + " -- and a slight change");
         assertEquals(1, updater.getUnappliedChanges().size());
     }
+
+    @Test
+    public void doNotUpdateSameContents() throws SQLException {
+        Updater updater = new Updater(TABLE_NAME);
+        updater.initialize(getConnection(), "");
+        String createTable = "create table test_table (\n"
+                + "  id int auto_increment not null\n"
+                + ")";
+        updater.update("file1.sql", createTable);
+        updater.update("file2.sql", createTable);
+        assertEquals(1, updater.getUnappliedChanges().size());
+    }
 }


### PR DESCRIPTION
The latest change intended to prevent updates from occurring when the
SQL had changed but the description was constant. The intention was to
prevent updates that had already been applied from being re-applied.

However, after that change it was discovered that uptodater files have
been modified in the past to change their description but keep the same
SQL. This use case was not anticipated and as a result our change caused
those uptodaters to be eligible for reapplication. This is a problem.

The code has thus been updated to handle both possible cases of
previously known uptodaters:
- Same SQL
- Same description

In either case, the uptodater should not be eligible for reapplication.

This commit handles these two cases. This handles the following cases:
- Already run uptodater description renamed (as was discovered)
- Already run uptodater SQL changed (what we're trying to prevent)